### PR TITLE
Bump SDK version to 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=5.6.0",
     "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-    "workos/workos-php": "^1.14.0"
+    "workos/workos-php": "^1.16.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15 || ^3.6",

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS\Laravel;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP Laravel";
-    public const SDK_VERSION = '1.6.0';
+    public const SDK_VERSION = '1.7.0';
 }


### PR DESCRIPTION
- Use `"workos/workos-php": "^1.16.0"`