### PR TITLE
Bump version to v2.0.0 (#37)

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS\Laravel;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP Laravel";
-    public const SDK_VERSION = '1.9.0';
+    public const SDK_VERSION = '2.0.0';
 }


### PR DESCRIPTION
In response to https://github.com/workos/workos-php-laravel/pull/37#issuecomment-1343111405

v1.9.0 was removed and I'm bumping the version to v2.0.0 since we updated the `workos-php` to a major version.