### PR TITLE
Bump version and workos-php to 4.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "workos/workos-php": "^v3.3.0"
+    "workos/workos-php": "^v4.0.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15 || ^3.6",

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS\Laravel;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP Laravel";
-    public const SDK_VERSION = '3.1.0';
+    public const SDK_VERSION = '4.0.0';
 }


### PR DESCRIPTION
## Breaking Change
* Bump `workos-php` package version to v2.1.0 (https://github.com/workos/workos-php-laravel/pull/36) (follow [workos/workos-php releases](https://github.com/workos/workos-php/releases) to catch the latest changes)