### PR TITLE
Migrate our CI to run on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+        laravel: ['7.*', '8.*', '9.*', '10.*']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          tools: composer
+          coverage: none
+
+      - name: Run composer install
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --no-interaction --no-suggest --prefer-dist
+
+      - name: Lint and formatting
+        run: |
+          composer run-script format-check
+
+      - name: Run tests
+        run: |
+          composer run-script test


### PR DESCRIPTION
We are moving our CI off of Semaphore.

I've disabled the Semaphore check as "Required" so that this PR can merge. The Semaphore config is very old and is now erroring out completely as it's using a deprecated image.